### PR TITLE
Throw an exception if there is still a ajax call after the timeout

### DIFF
--- a/Traits/MinkTrait.php
+++ b/Traits/MinkTrait.php
@@ -4,6 +4,7 @@ namespace A5sys\MinkContext\Traits;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use A5sys\MinkContext\Exception\ElementNotVisibleException;
+use Behat\Mink\Exception\ExpectationException;
 
 /**
  *
@@ -145,10 +146,16 @@ trait MinkTrait
      * I wait for all ajax done
      *
      * @When /^(?:|I )wait for ajax to be done$/
+     * @throws \Behat\Mink\Exception\ExpectationException
      */
     public function iWaitForAjaxDone()
     {
-        $this->getSession()->wait($this->ajaxTimeout, '(0 === jQuery.active)');
+        if ($this->getSession()->wait($this->ajaxTimeout, '(0 === jQuery.active)') === false) {
+            throw new ExpectationException(
+                sprintf('There is still an ajax call active after %d milliseconds.', $this->ajaxTimeout),
+                $this->getSession()
+            );
+        };
     }
 
     /**


### PR DESCRIPTION
Vu avec Thomas par tel : Si il y a toujours un appel ajax actif après le timeout, les tests continuent ce qui peut poser problème. Avec ce changement, une exception est lancée.

Quelques questions :
- Est-ce que ce doit être le comportement par défaut ? (Risque de casser des tests existants)
- Offrir la possibilité de surcharger le timeout directement depuis la feature ? ("Genre I wait xxxx milliseconds for the ajax to be done")
- Lancer une exception seulement si la durée de l'attente est spécifiée ?